### PR TITLE
Update to most recent software versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-# Compiled class file
+# IDE files
+.idea
+
+# Build artifacts
+.gradle
+build
 *.class
 
 # Log file

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,17 @@
+*********
+Changelog
+*********
+
+
+in progress
+===========
+
+
+2021-04-27 0.2
+==============
+- Update to most recent software versions
+
+
+2018-10-15 0.1
+==============
+- Initial release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+run:
+	bin/build-and-submit.sh

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,14 @@ Build Flink Job
 
     $ ./gradlew build
 
+Submit Flink Job
+================
+
+.. code:: console
+
+    make run
+
+
 Flink Job Configurations
 ========================
 

--- a/bin/build-and-submit.sh
+++ b/bin/build-and-submit.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Build job and submit to Flink
+
+# Version of the jar file.
+# TODO: Extract from `build.gradle`.
+VERSION="0.2"
+JARFILE="cratedb-flink-jobs-${VERSION}.jar"
+
+# Build job
+./gradlew build
+
+# Upload and invoke job
+docker run -it \
+  --network=scada-demo \
+  --volume=$(pwd)/build/libs/${JARFILE}:/${JARFILE} flink:1.12 \
+    \
+    flink run --jobmanager=flink-jobmanager:8081 /${JARFILE} \
+      --kafka.servers kafka-broker:9092 \
+      --kafka.topic rides \
+      --crate.hosts cratedb:5432 \
+      --crate.table taxi_rides

--- a/build.gradle
+++ b/build.gradle
@@ -20,33 +20,43 @@ archivesBaseName = 'cratedb-flink-jobs'
 version = 0.2
 
 ext {
-    flinkVersion = '1.6.2'
-    flinkJacksonVersion = '2.7.4'
-    crateJDBCVersion = '2.4.0'
+    scalaVersion = '2.12'
+    flinkVersion = '1.12.2'
+    jacksonVersion = '2.12.3'
+    crateJDBCVersion = '2.6.0'
+    postgresJDBCVersion = '42.2.20'
 }
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 configurations {
-    // exclude following dependencies from our shadowJar
-    runtime.exclude module: 'flink-java'
-    runtime.exclude module: 'flink-streaming-java_2.11'
-    runtime.exclude module: 'flink-clients_2.11'
+    // Exclude following dependencies from our shadowJar
+    runtime.exclude module: "flink-java"
+    runtime.exclude module: "flink-streaming-java_${scalaVersion}"
+    runtime.exclude module: "flink-clients_${scalaVersion}"
 }
 
 dependencies {
-    // flink
+    // Flink
+    // https://mvnrepository.com/artifact/org.apache.flink
     compile "org.apache.flink:flink-java:${flinkVersion}"
-    compile "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"
-    compile "org.apache.flink:flink-jdbc:${flinkVersion}"
+    compile "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}"
+    compile "org.apache.flink:flink-connector-jdbc_${scalaVersion}:${flinkVersion}"
 
-    // crate
+    // Kafka
+    // https://mvnrepository.com/artifact/org.apache.flink
+    // https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype
+    compile "org.apache.flink:flink-connector-kafka_${scalaVersion}:${flinkVersion}"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
+
+    // CrateDB
+    // https://mvnrepository.com/artifact/io.crate
+    // https://mvnrepository.com/artifact/org.postgresql
     compile "io.crate:crate-jdbc:${crateJDBCVersion}"
+    // TODO: Currently raises `org.postgresql.util.PSQLException: No hstore extension installed.`.
+    //       compile "org.postgresql:postgresql:${postgresJDBCVersion}"
 
-    // kafka
-    compile "org.apache.flink:flink-connector-kafka-0.10_2.11:${flinkVersion}"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${flinkJacksonVersion}"
 }
 
 shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 group = 'io.crate'
-archivesBaseName = 'kafka-flink-crate'
-version = 0.1
+archivesBaseName = 'cratedb-flink-jobs'
+version = 0.2
 
 ext {
     flinkVersion = '1.6.2'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'kafka-crate-flink'
+rootProject.name = 'cratedb-flink-jobs'


### PR DESCRIPTION
Hi there,

this patch updates `build.gradle` to use the most recent software versions of those packages:

```
ext {
    scalaVersion = '2.12'
    flinkVersion = '1.12.2'
    jacksonVersion = '2.12.3'
    crateJDBCVersion = '2.6.0'
    postgresJDBCVersion = '42.2.20'
}
```

Along the lines, it adjusts the code for compatibility and adds a helper program to build and submit the job to Flink.

With kind regards,
Andreas.